### PR TITLE
ignore carriers to fix animal issue

### DIFF
--- a/Source/raceQuestPawn/PawnGenerator_GeneratePawn.cs
+++ b/Source/raceQuestPawn/PawnGenerator_GeneratePawn.cs
@@ -68,7 +68,7 @@ public class PawnGenerator_GeneratePawn
                         var optionsplus = pawnGroupMaker.options;
                         //miss traders.
                         optionsplus.AddRange(pawnGroupMaker.traders);
-                        optionsplus.AddRange(pawnGroupMaker.carriers);
+                        //optionsplus.AddRange(pawnGroupMaker.carriers);
                         optionsplus.AddRange(pawnGroupMaker.guards);
                         foreach (var pawnGenOption in optionsplus)
                         {
@@ -145,7 +145,7 @@ public class PawnGenerator_GeneratePawn
                     var optionsplus = pawnGroupMaker.options;
                     //miss traders.
                     optionsplus.AddRange(pawnGroupMaker.traders);
-                    optionsplus.AddRange(pawnGroupMaker.carriers);
+                    //optionsplus.AddRange(pawnGroupMaker.carriers);
                     optionsplus.AddRange(pawnGroupMaker.guards);
                     foreach (var pawnGenOption in optionsplus)
                     {


### PR DESCRIPTION
There is occasionally someone who gives feedback on my forked version on pawn becoming animal in specific situations but they were actually using original version. 
At beginning I thought it's because of compatibility issue, but this time I reviewed my previous commit here, it seemed it was my second commit here to fix trader issue when I didn't know carriers were only for animals, which somehow added carriers into the generating list, then I fogot about this commit, and worked on forked version.
I haven't realized the problem I left here until now, sorry.